### PR TITLE
feat: add compatibility for x.com URLs given Twitter name change

### DIFF
--- a/src/utils/tweet.ts
+++ b/src/utils/tweet.ts
@@ -3,7 +3,7 @@ export function extractTweetId(tweetUrl: string): string | null {
     return null;
   }
   tweetUrl = tweetUrl.trim();
-  const pattern = /(https?:\/\/)??twitter\.com\/(?:#!\/)?(\w+|_|\s)+\/status\/(\d+)/i;
+  const pattern = /(https?:\/\/)??(?:twitter|x)\.com\/(?:#!\/)?(\w+|_|\s)+\/status\/(\d+)/i;
   const match = tweetUrl.match(pattern);
   return match?.at(-1) ?? null;
 }


### PR DESCRIPTION
### Summary 🎯

<!-- Please explain the purpose, and **link** any relevant issues-->

This is a super simple PR to allow for x.com in addition to twitter.com tweet URLs given they changed their name to x.com.

PLEASE TEST as I do not have the ability or time right now to try and clone, setup and test but am fairly confident my change should work out of the box.

### Changes 🔁

- add x.com to the regex for parsing the tweet id